### PR TITLE
Minor fix to avoid an unnecessary warning message.

### DIFF
--- a/src/DisplayObjectMixin.ts
+++ b/src/DisplayObjectMixin.ts
@@ -58,7 +58,6 @@ declare module PIXI {
 if (PIXI.particles && PIXI.particles.ParticleContainer) {
     PIXI.particles.ParticleContainer.prototype.layerableChildren = false;
 }
-
-if ((PIXI as any).ParticleContainer) {
+else if ((PIXI as any).ParticleContainer) {
     (PIXI as any).ParticleContainer.prototype.layerableChildren = false;
 }


### PR DESCRIPTION
I was getting a deprecation warning about the ParticleContainer being moved, using pixi 4.4.2, and I think this should fix that without any issues.