### PR TITLE
Don't try to call methods on an undefined group

### DIFF
--- a/dist/pixi-layers.js
+++ b/dist/pixi-layers.js
@@ -610,7 +610,7 @@ var pixi_display;
                 return;
             }
             var group = displayObject.parentGroup;
-            if (group !== null) {
+            if (group != null) {
                 group.addDisplayObject(this, displayObject);
             }
             var layer = displayObject.parentLayer;

--- a/src/Stage.ts
+++ b/src/Stage.ts
@@ -61,7 +61,7 @@ namespace pixi_display {
             }
 
             let group = displayObject.parentGroup;
-            if (group !== null) {
+            if (group != null) {
                 group.addDisplayObject(this, displayObject);
             }
             const layer = displayObject.parentLayer;


### PR DESCRIPTION
Remember that both "null" and "undefined" exist, I get why one would want to do extra strict comparisons, but in this particular case, we don't want to call methods on an undefined object (I ran into this problem).