### PR TITLE
fix void 0 , null parentGroup

### DIFF
--- a/src/Stage.ts
+++ b/src/Stage.ts
@@ -61,9 +61,7 @@ namespace pixi_display {
             }
 
             let group = displayObject.parentGroup;
-            if (group !== null) {
-                group.addDisplayObject(this, displayObject);
-            }
+            group && group.addDisplayObject(this, displayObject);
             const layer = displayObject.parentLayer;
             if (layer !== null) {
                 group = layer.group;


### PR DESCRIPTION
in some context we can have undefined for **parentGroup** 
Let show some scenery and context.
**Context1**: we get default data from a display obj but we don't want **parentGroup** because it out specific container stage or we need to define later for x reason.
```javascript
    // the DataValues will used for make saveGame or dataEditor manager
    CageContainer.prototype.getDataValues = function(dataBase, textureName) {
        const def = !!dataBase;
        const isSpine      = def? (dataBase.type === "spineSheet"     ) : (this.type === "spineSheet"     );
        const isAnimations = def? (dataBase.type === "animationSheet" ) : (this.type === "animationSheet" );
        // parent data value
        const p = {
            type       : def? dataBase   .type                                        : this .type       , // locked
            textureName: def? textureName                                             : this .textureName, // locked
            dataName   : def? dataBase   .name                                        : this .dataName   , // locked
            groupID    : def? dataBase   .dirArray[dataBase.dirArray.length-1]        : this .groupID    , // asigner un groupe dapartenance ex: flags
            name       : def? textureName+Math.random().toString(36).substring(2, 12) : this .name       , // asigner un nom unique
            description: def? dataBase   .root                                        : this .description, // un description aide memoire
            // observable point
            position : def? [0,0] : [this.position .x, this.position .y],
            scale    : def? [1,1] : [this.scale    .x, this.scale    .y],
            skew     : def? [0,0] : [this.skew     .x, this.skew     .y],
            pivot    : def? [0,0] : [this.pivot    .x, this.pivot    .y],
            // transform
            rotation : def? 0 : this.rotation ,
            alpha    : def? 1 : this.alpha    ,
            // other
            autoGroups  : def? new Array(7).fill(false) : this.autoGroups                            , // permet de changer automatiquement de layers selon player
            zIndex      : def?           0              : this.zIndex                                , // locked
            parentGroup : def?          void 0          : this.parentGroup && this.parentGroup.zIndex, //  for editor, need to manual set parentGroup on addMouse 
            // animations
            ...isAnimations && {
                totalFrames    :def? dataBase.textures[textureName].length : this.totalFrames    , // locked
                animationSpeed :def? 1                                     : this.animationSpeed ,
                loop           :def? false                                  : this.loop           ,
            },
        };
```

**Context2**:
Relative to last spine-update
https://github.com/pixijs/pixi-spine/pull/270
we can want get only the list of arrays for diffuse and normal but without hack **parentGroup** 
```javascript
var listDN = spine.hackAttachmentGroups("_n"); // (nameSuffix, group_n,group_d) only return a lists
```
Also, i think we're talking about the same problem here but in a different context.
https://github.com/pixijs/pixi-display/pull/33

**I propose this change, knowing that the parent Group can not be 0.**
But if "undefined" it crash.
i test change in my context and it look fine and doesn't seem break something.
And also we get small micro optimisation for this loop without **!==**

what do you think about this?